### PR TITLE
Use camelcase for agent name instead of underscore.

### DIFF
--- a/bin/smith-datadog
+++ b/bin/smith-datadog
@@ -109,7 +109,7 @@ class Smith::Datadog
 
   # Return the service name
   def service(name)
-    "#{SERVICE_NAME.downcase}.#{name.to_s.underscore}"
+    "#{SERVICE_NAME.downcase}.#{name.to_s}"
   end
 
   def state(state)


### PR DESCRIPTION
It makes restarting agent easier (by copy and paste agent name) to
`smithctl start`
